### PR TITLE
add pop up when click a bus to report capacity

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -15,6 +15,7 @@ const API_BASE_URL = "https://api.translink.ca/rttiapi/v1";
 const stopsRouter = require("./routes/busStops");
 const routesRouter = require("./routes/busRoutes");
 const estimatesRouter = require("./routes/estimates");
+const capacityRouter = require("./routes/busCapacity");
 const axios = require("axios");
 
 const app = express();
@@ -35,6 +36,7 @@ app.use(cors());
 app.use("/stops", stopsRouter);
 app.use("/routes", routesRouter);
 app.use("/estimates", estimatesRouter);
+app.use("/capacity", capacityRouter);
 
 setInterval(fetchBuses, 60000);
 

--- a/back-end/controllers/busCapacityController.js
+++ b/back-end/controllers/busCapacityController.js
@@ -1,0 +1,86 @@
+const BusCapacity = require("../model/bus-capacity");
+const isNil = require("../utils");
+const Interval_limit = 30;
+
+const getBusCapacity = async (req, res) => {
+  // remove outdated capacity info
+  let oldBusCapacity = await BusCapacity.aggregate([
+    {
+      $addFields: {
+        reportTimeDiff: {
+          $dateDiff: {
+            startDate: "$ReportTime",
+            endDate: "$$NOW",
+            unit: "minute",
+          },
+        },
+      },
+    },
+    {
+      $match: { reportTimeDiff: { $gt: Interval_limit } },
+    },
+  ]);
+  oldBusCapacity = oldBusCapacity.map(function (bus) {
+    return bus.VehicleNo;
+  });
+  await BusCapacity.deleteMany({ VehicleNo: { $in: oldBusCapacity } });
+
+  // find average capacity level of the bus and round it to 1 decimal place
+  const busNo = req.params.busNo;
+  const capacity = await BusCapacity.aggregate([
+    {
+      $match: { VehicleNo: { $eq: busNo } },
+    },
+    {
+      $group: {
+        _id: "$VehicleNo",
+        avgCapacity: { $avg: "$Capacity" },
+      },
+    },
+    {
+      $addFields: {
+        roundedAvgCapacity: { $round: ["$avgCapacity", 1] },
+      },
+    },
+    { $project: { roundedAvgCapacity: 1, countUsefulReport: 1 } },
+  ]);
+
+  // count the number of valid capacity report
+  // cannot be generated at the same time with average capacity
+  const usefulInfoCount = await BusCapacity.aggregate([
+    {
+      $match: { VehicleNo: { $eq: busNo } },
+    },
+    { $count: "countUsefulReport" },
+  ]);
+
+  if (capacity.length === 0) {
+    return res.status(200).send({ _id: busNo, avgCapacity: -1, countUsefulReport: 0 });
+  } else {
+    let obj = {...capacity[0], ...usefulInfoCount[0]}
+    return res.status(200).send(obj);
+  }
+};
+
+const postBusCapacity = async (req, res) => {
+  const busNo = req.params.busNo;
+  const curCapcity = req.body.capacityLevel;
+
+  if (curCapcity > 5 || curCapcity < 0) {
+    return res.status(400).send("Invalid Capacity Info!");
+  }
+
+  try {
+    BusCapacity.create({
+      VehicleNo: busNo,
+      Capacity: curCapcity,
+      ReportTime: new Date(),
+    });
+  } catch (err) {
+    console.log(err);
+    return res.status(400).send(busNo + "bus report failed!");
+  }
+  return res.status(200).send(busNo + "bus report successfully!");
+};
+
+module.exports = { getBusCapacity, postBusCapacity };

--- a/back-end/model/bus-capacity.js
+++ b/back-end/model/bus-capacity.js
@@ -1,0 +1,12 @@
+const mongoose = require("mongoose");
+
+const busCapacitySchema = new mongoose.Schema(
+  {
+    VehicleNo: { type: String, required: true },
+    Capacity: { type: Number, required: true },
+    ReportTime: { type: Date, required: true, default: Date.now },
+  },
+  { collection: "bus-capacity" }
+);
+
+module.exports = mongoose.model("bus-capacity", busCapacitySchema);

--- a/back-end/routes/busCapacity.js
+++ b/back-end/routes/busCapacity.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const { getBusCapacity, postBusCapacity } = require("../controllers/busCapacityController");
+const router = express.Router();
+
+// GET 
+router.get("/:busNo", async (req, res) => {
+    await getBusCapacity(req, res);
+  });
+
+router.post("/:busNo", async (req, res) => {
+  await postBusCapacity(req, res);
+});
+
+module.exports = router;

--- a/front-end/src/components/CapacityDialog.js
+++ b/front-end/src/components/CapacityDialog.js
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { styled } from '@mui/material/styles';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+import Typography from '@mui/material/Typography';
+import CapacityRatings from './CapacityRating';
+
+import {fetchBusCapacityAsync} from 'store/thunks';
+import { useDispatch } from 'react-redux';
+
+const BootstrapDialog = styled(Dialog)(({ theme }) => ({
+  '& .MuiDialogContent-root': {
+    padding: theme.spacing(2)
+  },
+  '& .MuiDialogActions-root': {
+    padding: theme.spacing(1)
+  }
+}));
+
+function BootstrapDialogTitle(props) {
+  const { children, onClose, ...other } = props;
+
+  return (
+    <DialogTitle sx={{ fontSize: 16, m: 0, pl: 2, pt: 2, pb: 1 }} {...other}>
+      {children}
+      {onClose ? (
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{
+            position: 'absolute',
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500]
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+      ) : null}
+    </DialogTitle>
+  );
+}
+
+BootstrapDialogTitle.propTypes = {
+  children: PropTypes.node,
+  onClose: PropTypes.func.isRequired
+};
+
+export default function CapacityDialog({ dialogOpen, dialogToggle, bus }) {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchBusCapacityAsync(bus['VehicleNo']));
+  }, []);
+
+  return (
+    <div>
+      <BootstrapDialog fullWidth
+  maxWidth="xs" onClose={dialogToggle} aria-labelledby="customized-dialog-title" open={dialogOpen}>
+        <BootstrapDialogTitle id="customized-dialog-title" onClose={dialogToggle}>
+          {bus['RouteNo'] + '    ' + bus['Direction']}
+        </BootstrapDialogTitle>
+        <Typography sx={{ m: 0, pl: 2 }}>{'Destination: ' + bus['Destination']}</Typography>
+        <DialogContent dividers>
+          <CapacityRatings busNo={bus['VehicleNo']}/>
+        </DialogContent>
+      </BootstrapDialog>
+    </div>
+  );
+}

--- a/front-end/src/components/CapacityRating.js
+++ b/front-end/src/components/CapacityRating.js
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import Rating from '@mui/material/Rating';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+import * as constants from '../store/constants';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPerson } from '@fortawesome/free-solid-svg-icons';
+import { useDispatch, useSelector } from 'react-redux';
+import Button from '@mui/material/Button';
+import { reportBusCapacityAysnc } from '../store/thunks';
+
+const labels = {
+  0.5: constants.BUS_CAPACITY_LEVEL.EMPTY,
+  3: constants.BUS_CAPACITY_LEVEL.BUSY,
+  5: constants.BUS_CAPACITY_LEVEL.FULL
+};
+
+
+
+function getHoverLabelText(value) {
+  return `${labels[value]}`;
+}
+
+const StyledRating = styled(Rating)({
+  '& .MuiRating-iconFilled': {
+    color: '#1565C0'
+  },
+  '& .MuiRating-iconHover': {
+    color: '#1565C0'
+  }
+});
+
+export default function CapacityRatings({busNo}) {
+  const [value, setValue] = React.useState(-1);
+  const [hover, setHover] = React.useState(-1);
+  const dispatch = useDispatch();
+  let selectedBusCapacity = useSelector((state) => state.busyBus.commuter.selectedBusCapacity).roundedAvgCapacity;
+  const usefulReportCount =  useSelector((state) => state.busyBus.commuter.selectedBusCapacity).countUsefulReport;
+  const handleBusCapacityReport = () => {
+    dispatch(reportBusCapacityAysnc({busNo, capacityLevel:value}));
+  };
+  
+  function getReadOnlyLabelText(value) {
+    if (value === -1 || value === undefined) return "no report";
+    return `Out of ${usefulReportCount} report`;
+  }
+
+  if (selectedBusCapacity === undefined) {
+    selectedBusCapacity = 0;
+  }
+
+  return (
+    <Stack
+    spacing={1}
+    >
+      <Typography gutterBottom>Current Capacity:</Typography>
+      <Box
+      sx={{
+        width: 200,
+        display: 'flex',
+        alignItems: 'center',
+      }}
+    >
+      <StyledRating
+        value={selectedBusCapacity < 0? 0 : selectedBusCapacity}
+        precision={0.5}
+        readOnly
+        icon={<FontAwesomeIcon icon={faPerson} />}
+        emptyIcon={<FontAwesomeIcon icon={faPerson} />}
+      />
+      <Box sx={{ ml: 2 }}>{getReadOnlyLabelText(selectedBusCapacity)}</Box>
+    </Box>
+      
+      <Typography gutterBottom>Report Capacity:</Typography>
+      <Box
+        sx={{
+          width: 200,
+          display: 'flex',
+          alignItems: 'center'
+        }}
+      >
+        <Rating
+          name="hover-feedback"
+          value={value}
+          precision={0.5}
+          getLabelText={getHoverLabelText}
+          onChange={(event, newValue) => {
+            setValue(newValue);
+          }}
+          onChangeActive={(event, newHover) => {
+            setHover(newHover);
+          }}
+          icon={<FontAwesomeIcon icon={faPerson} />}
+          emptyIcon={<FontAwesomeIcon icon={faPerson} />}
+        />
+        {value !== null && <Box sx={{ ml: 2 }}>{labels[hover !== -1 ? hover : value]}</Box>}
+      </Box>
+      <Button autoFocus onClick={handleBusCapacityReport}>
+          Save changes
+      </Button>
+    </Stack>
+  );
+}

--- a/front-end/src/store/BusyBusReducer.js
+++ b/front-end/src/store/BusyBusReducer.js
@@ -1,11 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
 // import { v4 as uuid } from 'uuid';
 // import { BUS_CAPACITY_LEVEL } from './constants';
-import { fetchBusesOnStopAsync, fetchRoutesAsync, fetchStopRouteEstimatesAsync, fetchStopsOnRouteAsync } from './thunks';
+import { fetchBusesOnStopAsync, fetchRoutesAsync, fetchStopRouteEstimatesAsync, fetchStopsOnRouteAsync, fetchBusCapacityAsync } from './thunks';
 
 export const initialState = {
   defaultId: 'default',
   opened: false,
+  busPopupOpened: false,
   commuter: {
     busRoutesSearchResult: [],
     busStopsSearchResult: [],
@@ -13,6 +14,7 @@ export const initialState = {
     selectedBusStop: {},
     stopRoutesList: [],
     selectedBusId: '',
+    selectedBusCapacity: 0,
     availableRoutes: [],
     busesToShow: [],
     estimates: []
@@ -31,6 +33,9 @@ const busyBusSlice = createSlice({
   reducers: {
     setShowSidebar: (state, action) => {
       state.opened = action.payload;
+    },
+    setShowBusPopUp:  (state, action) => {
+      state.busPopupOpened = action.payload;
     },
     clearStopsAndBuses: (state) => {
       state.commuter.busStopsSearchResult = [];
@@ -56,6 +61,12 @@ const busyBusSlice = createSlice({
     });
     builder.addCase(fetchStopRouteEstimatesAsync.fulfilled, (state, action) => {
       state.commuter.estimates = action.payload;
+    });
+    builder.addCase(fetchBusCapacityAsync.fulfilled, (state, action) => {
+      state.commuter.selectedBusCapacity = action.payload;
+    });
+    builder.addCase(fetchBusCapacityAsync.rejected, (state) => {
+      state.commuter.selectedBusCapacity = -1;
     });
   }
 });

--- a/front-end/src/store/actionTypes.js
+++ b/front-end/src/store/actionTypes.js
@@ -10,10 +10,10 @@ export const FETCH_ESTIMATE = '@busyBus/FETCH_ESTIMATE';
 export const SEARCH_BUS_STOP = '@busyBus/SEARCH_BUS_STOP';
 export const GET_BUS_STOPS_BY_ROUTE = '@busyBus/GET_BUS_STOPS_BY_ROUTE';
 export const GET_UPCOMING_BUSES = '@busyBus/GET_UPCOMING_BUSES';
-export const GET_BUS_CAPACITY = '@busyBus/GET_BUS_CAPACITY';
+export const FETCH_BUS_CAPACITY = '@busyBus/FETCH_BUS_CAPACITY';
 
 // Passenger Actions
 export const GET_PASSENGER_LOCATION = '@busyBus/GET_PASSENGER_LOCATION';
 export const GET_NEARBY_BUSES = '@busyBus/GET_UPCOMING_BUSES';
 export const SELECT_CURRENT_BUS = '@busyBus/SELECT_CURRENT_BUS';
-export const SUBMIT_BUS_CAPACITY = '@busyBus/SUBMIT_BUS_CAPACITY';
+export const REPORT_BUS_CAPACITY = '@busyBus/REPORT_BUS_CAPACITY';

--- a/front-end/src/store/constants.js
+++ b/front-end/src/store/constants.js
@@ -2,8 +2,7 @@ export const gridSpacing = 3;
 export const drawerWidth = 260;
 export const appDrawerWidth = 320;
 export const BUS_CAPACITY_LEVEL = {
-  FULL: 'full',
-  BUSY: 'busy',
-  LESS_BUSY: 'less-busy',
-  EMPTY: 'empty'
+  FULL: 'Full',
+  BUSY: 'Busy',
+  EMPTY: 'Empty'
 };

--- a/front-end/src/store/service.js
+++ b/front-end/src/store/service.js
@@ -32,11 +32,33 @@ const fetchStopRouteEstimates = async ({ busStop, selectedRoute }) => {
   return response.json();
 };
 
+const fetchBusCapacity = async ({ busNo }) => {
+  const response = await fetch(`http://localhost:3001/capacity/${busNo}`, {
+    method: 'GET'
+  });
+
+  return response.json();
+};
+
+const reportBusCapacity = async ({ busNo, capacityLevel }) => {
+  const response = await fetch(`http://localhost:3001/capacity/${busNo}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({capacityLevel: capacityLevel})
+  });
+
+  return response.json();
+};
+
 const BusyBusService = {
   fetchRoutes,
   fetchStopsOnRoute,
   fetchBusesOnStop,
-  fetchStopRouteEstimates
+  fetchStopRouteEstimates,
+  fetchBusCapacity,
+  reportBusCapacity
 };
 
 export default BusyBusService;

--- a/front-end/src/store/thunks.js
+++ b/front-end/src/store/thunks.js
@@ -1,5 +1,12 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { FETCH_ROUTES, FETCH_BUSES_ON_STOP, FETCH_STOP_ON_ROUTE, FETCH_ESTIMATE } from './actionTypes';
+import {
+  FETCH_ROUTES,
+  FETCH_BUSES_ON_STOP,
+  FETCH_STOP_ON_ROUTE,
+  FETCH_ESTIMATE,
+  FETCH_BUS_CAPACITY,
+  REPORT_BUS_CAPACITY
+} from './actionTypes';
 import BusyBusService from './service';
 
 export const fetchRoutesAsync = createAsyncThunk(FETCH_ROUTES, async () => {
@@ -16,4 +23,12 @@ export const fetchBusesOnStopAsync = createAsyncThunk(FETCH_BUSES_ON_STOP, async
 
 export const fetchStopRouteEstimatesAsync = createAsyncThunk(FETCH_ESTIMATE, async ({ busStop, selectedRoute }) => {
   return await BusyBusService.fetchStopRouteEstimates({ busStop, selectedRoute });
+});
+
+export const fetchBusCapacityAsync = createAsyncThunk(FETCH_BUS_CAPACITY, async ({ busNo }) => {
+  return await BusyBusService.fetchBusCapacity({ busNo });
+});
+
+export const reportBusCapacityAysnc = createAsyncThunk(REPORT_BUS_CAPACITY, async ({ busNo, capacityLevel }) => {
+  return await BusyBusService.reportBusCapacity({ busNo, capacityLevel });
 });


### PR DESCRIPTION
when no report has been submitted for the bus:
![image](https://github.com/dburenok/busybus/assets/75555554/abb7aa15-ea26-4042-b1d4-c0f056112acf)

capacity can be submitted by hovering on the rating and click on save changes. 
![image](https://github.com/dburenok/busybus/assets/75555554/858bd90d-efa9-4605-8e7a-d1716a2ad2c0)

Then re-click on the bus and wait for 1-2 sec, the capacity would be updated
![image](https://github.com/dburenok/busybus/assets/75555554/7de36e66-ced7-45d4-8dbb-67d8e3aafd28)

The capacity value is the average of all the reports within 30 minutes. The precision of the rating is 0.5, meaning that 3.2 will be rounded to 3 and 3.3 will be rounded to 3.5.
![image](https://github.com/dburenok/busybus/assets/75555554/bf23513a-d851-49d2-bb7f-2c5435faea87)

The outdated report (more than 30 minutes from now) will be deleted from the database with next get call.