### PR TITLE
Fix mobile search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,46 @@
 # BusyBus
+
 Group members: Dmitriy B., Dennis F., Lisa L. and Brendon S.
 
 ## Project Progress 1
+
 #### Project Description
-This project is targeted at Vancouver bus-takers who want to have better control over their transit plans. It will allow users to see the capacity of Translink buses in real-time, and users taking a bus will be able to report the capacity of the current bus they’re on. We plan to store daily and weekly data about transit availability as well as usage data, such as our users’ most common bus stops and bus route numbers. If given enough time, we would like to implement ML-supported data analytics so that users can get notified when their usual route is more or less busy than usual as well as suggestions for alternate routes. Also, we plan to implement a point tracking system which will allow users to earn points when they report data, and consume points when they request bus information. 
+
+This project is targeted at Vancouver bus-takers who want to have better control over their transit plans. It will allow users to see the capacity of Translink buses in real-time, and users taking a bus will be able to report the capacity of the current bus they’re on. We plan to store daily and weekly data about transit availability as well as usage data, such as our users’ most common bus stops and bus route numbers. If given enough time, we would like to implement ML-supported data analytics so that users can get notified when their usual route is more or less busy than usual as well as suggestions for alternate routes. Also, we plan to implement a point tracking system which will allow users to earn points when they report data, and consume points when they request bus information.
 
 #### Project task requirements
+
 ##### Minimal
-* A web-based interface that shows bus stops on a map
-    * Create a starter React project with a nav bar (dashboard page and about page)
-    * Implement a map using a map library which works well with React (google maps/openmap/etc) and add bus stop icons using dummy location data, showing it on the dashboard page
-* Automatically fetching Translink API data once every minute/30 seconds and update bus locations on the map for a selected bus stop
-    * Set up the back-end to periodically fetch Translink API data and save it to a database
-    * When the user clicks on a bus stop, show an info box with the upcoming buses
-    * When the user clicks on one of the buses in the info box, take them to another map view where all the buses for that route will be displayed
-    * Connect the front-end to the back-end and populate the map with bus stops when the page loads, and show real bus information when a bus stop is clicked
-* Deploy the app (front-end and back-end) onto the web
-* The ability to “tap” on a bus and see how busy it is, given that the information is available
-* The ability to “tap” on a bus and submit its busyness/amount of free space
-* Rudimentary login system that lets the user login (thereby automatically signing up) by simply entering their email
+
+- A web-based interface that shows bus stops on a map
+  - Create a starter React project with a nav bar (dashboard page and about page)
+  - Implement a map using a map library which works well with React (google maps/openmap/etc) and add bus stop icons using dummy location data, showing it on the dashboard page
+- Automatically fetching Translink API data once every minute/30 seconds and update bus locations on the map for a selected bus stop
+  - Set up the back-end to periodically fetch Translink API data and save it to a database
+  - When the user clicks on a bus stop, show an info box with the upcoming buses
+  - When the user clicks on one of the buses in the info box, take them to another map view where all the buses for that route will be displayed
+  - Connect the front-end to the back-end and populate the map with bus stops when the page loads, and show real bus information when a bus stop is clicked
+- Deploy the app (front-end and back-end) onto the web
+- The ability to “tap” on a bus and see how busy it is, given that the information is available
+- The ability to “tap” on a bus and submit its busyness/amount of free space
+- Rudimentary login system that lets the user login (thereby automatically signing up) by simply entering their email
+
 ##### Standard
-* The web-based interface is responsive and works well on small screens
-* The user can use their location to find the nearest bus in order to submit busyness level (without having to look for their bus on the map)
-* The user can use their location to find the nearest bus stop and see the list of upcoming buses along with their capacity (which will use up some of the user’s points)
-* Point tracking system which grants points to users when they submit bus information - the points are later used to request busyness level for incoming buses
+
+- The web-based interface is responsive and works well on small screens
+- The user can use their location to find the nearest bus in order to submit busyness level (without having to look for their bus on the map)
+- The user can use their location to find the nearest bus stop and see the list of upcoming buses along with their capacity (which will use up some of the user’s points)
+- Point tracking system which grants points to users when they submit bus information - the points are later used to request busyness level for incoming buses
+
 ##### Stretch
-* When busyness/free space information is unavailable for a bus, we estimate it based on statistical data from previous days/weeks to provide a best guess
-* Email confirmation for user login
+
+- When busyness/free space information is unavailable for a bus, we estimate it based on statistical data from previous days/weeks to provide a best guess
+- Email confirmation for user login
 
 #### Sketch
+
 ![BusyBus (sketch)](https://github.com/dburenok/cpsc-455-project/assets/8009732/b6e009bd-dd90-4033-9c2b-ee1489862caf)
 
 #### Useful links
-* https://www.translink.ca/about-us/doing-business-with-translink/app-developer-resources
+
+- https://www.translink.ca/about-us/doing-business-with-translink/app-developer-resources

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -12,11 +12,16 @@ const mongoose_uri = `mongodb+srv://${MONGO_USER}:${MONGO_PASS}@busybuscluster0.
 const API_KEY = process.env.TRANSLINK_API_KEY;
 const API_BASE_URL = "https://api.translink.ca/rttiapi/v1";
 
+const BUS_FETCH_INTERVAL_SEC = 30;
+const REMOVE_OUT_OF_DATE_CAPACITY_INTERVAL_MIN = 5;
+const CAPACITY_INTERVAL_MINS = 30;
+
 const stopsRouter = require("./routes/busStops");
 const routesRouter = require("./routes/busRoutes");
 const estimatesRouter = require("./routes/estimates");
 const capacityRouter = require("./routes/busCapacity");
 const axios = require("axios");
+const BusCapacity = require("./model/bus-capacity");
 
 const app = express();
 
@@ -31,14 +36,18 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
-app.use(cors());
+app.use(cors({ origin: "https://busybus-front-end.onrender.com" }));
 
 app.use("/stops", stopsRouter);
 app.use("/routes", routesRouter);
 app.use("/estimates", estimatesRouter);
 app.use("/capacity", capacityRouter);
 
-setInterval(fetchBuses, 60000);
+setInterval(fetchBuses, BUS_FETCH_INTERVAL_SEC * 1000);
+setInterval(
+  removeOutOfDateCapacityInfo,
+  REMOVE_OUT_OF_DATE_CAPACITY_INTERVAL_MIN * 60 * 1000
+);
 
 module.exports = app;
 
@@ -51,4 +60,31 @@ async function fetchBuses() {
   await Bus.insertMany(buses);
 
   console.log(`Fetched and saved ${buses.length} buses to MongoDB`);
+}
+
+async function removeOutOfDateCapacityInfo() {
+  let outdatedBusCapacity = await BusCapacity.aggregate([
+    {
+      $addFields: {
+        reportTimeDiff: {
+          $dateDiff: {
+            startDate: "$ReportTime",
+            endDate: "$$NOW",
+            unit: "minute",
+          },
+        },
+      },
+    },
+    {
+      $match: { reportTimeDiff: { $gt: CAPACITY_INTERVAL_MINS } },
+    },
+  ]);
+
+  outdatedBusCapacity = outdatedBusCapacity.map((bus) => bus.VehicleNo);
+
+  const removed = await BusCapacity.deleteMany({
+    VehicleNo: { $in: outdatedBusCapacity },
+  });
+
+  console.log(`Removed ${removed.deletedCount} outdated bus capacities`);
 }

--- a/back-end/controllers/busRouteController.js
+++ b/back-end/controllers/busRouteController.js
@@ -1,6 +1,7 @@
 const BusStopOnRoute = require("../model/bus-stops-on-route");
 const BusStop = require("../model/bus-stop");
 const isNil = require("../utils");
+const Bus = require("../model/bus");
 
 const getRoutes = async (req, res) => {
   const routes = await BusStopOnRoute.find({});
@@ -20,4 +21,11 @@ const findRoute = async (req, res) => {
   res.send(stops);
 };
 
-module.exports = { getRoutes, findRoute };
+const getBusesOnRoute = async (req, res) => {
+  const selectedRoute = req.params.selectedRoute;
+  const busesOnRoutes = await Bus.find({ RouteNo: selectedRoute });
+
+  res.json(busesOnRoutes);
+};
+
+module.exports = { getRoutes, findRoute, getBusesOnRoute };

--- a/back-end/controllers/busStopController.js
+++ b/back-end/controllers/busStopController.js
@@ -1,5 +1,4 @@
 const BusStop = require("../model/bus-stop");
-const Bus = require("../model/bus");
 const SearchHistory = require("../model/search-history");
 const isNil = require("../utils");
 
@@ -30,14 +29,4 @@ const findStop = async (req, res) => {
   }
 };
 
-const getBusesOnStop = async (req, res) => {
-  const stopNo = req.params.stopNo;
-  const stop = await BusStop.findOne({ StopNo: stopNo });
-
-  const routes = stop["Routes"].split(", ").filter((route) => route !== "");
-  const busesOnRoutes = await Bus.find({ RouteNo: { $in: routes } });
-
-  res.json(busesOnRoutes);
-};
-
-module.exports = { getStops, findStop, getBusesOnStop };
+module.exports = { getStops, findStop };

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "back-end",
+  "name": "busybus-back-end",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "back-end",
+      "name": "busybus-back-end",
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.4.0",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "back-end",
+  "name": "busybus-back-end",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/back-end/public/index.html
+++ b/back-end/public/index.html
@@ -1,13 +1,11 @@
 <html>
+  <head>
+    <title>Express</title>
+    <link rel="stylesheet" href="/stylesheets/style.css" />
+  </head>
 
-<head>
-  <title>Express</title>
-  <link rel="stylesheet" href="/stylesheets/style.css">
-</head>
-
-<body>
-  <h1>Express</h1>
-  <p>Welcome to Express</p>
-</body>
-
+  <body>
+    <h1>Express</h1>
+    <p>Welcome to Express</p>
+  </body>
 </html>

--- a/back-end/public/stylesheets/style.css
+++ b/back-end/public/stylesheets/style.css
@@ -4,5 +4,5 @@ body {
 }
 
 a {
-  color: #00B7FF;
+  color: #00b7ff;
 }

--- a/back-end/routes/busCapacity.js
+++ b/back-end/routes/busCapacity.js
@@ -1,11 +1,14 @@
 const express = require("express");
-const { getBusCapacity, postBusCapacity } = require("../controllers/busCapacityController");
+const {
+  getBusCapacity,
+  postBusCapacity,
+} = require("../controllers/busCapacityController");
 const router = express.Router();
 
-// GET 
+// GET
 router.get("/:busNo", async (req, res) => {
-    await getBusCapacity(req, res);
-  });
+  await getBusCapacity(req, res);
+});
 
 router.post("/:busNo", async (req, res) => {
   await postBusCapacity(req, res);

--- a/back-end/routes/busRoutes.js
+++ b/back-end/routes/busRoutes.js
@@ -1,5 +1,10 @@
 const express = require("express");
-const { getRoutes, findRoute } = require("../controllers/busRouteController");
+const {
+  getRoutes,
+  findRoute,
+  getBusesOnStop,
+  getBusesOnRoute,
+} = require("../controllers/busRouteController");
 const router = express.Router();
 
 // GET all routes
@@ -16,6 +21,11 @@ router.get("/:routeNo", async (req, res) => {
 router.patch("/:routeNo", (req, res) => {
   // Stub - not implemented, can use this for updating a bus route capacity
   res.send("stub-patch");
+});
+
+// GET buses on a given bus stop
+router.get("/:selectedRoute/buses", async (req, res) => {
+  await getBusesOnRoute(req, res);
 });
 
 module.exports = router;

--- a/back-end/routes/busStops.js
+++ b/back-end/routes/busStops.js
@@ -1,19 +1,10 @@
 const express = require("express");
-const {
-  getStops,
-  findStop,
-  getBusesOnStop,
-} = require("../controllers/busStopController");
+const { getStops, findStop } = require("../controllers/busStopController");
 const router = express.Router();
 
 // GET all bus stops
 router.get("/", async (req, res) => {
   await getStops(req, res);
-});
-
-// GET buses on a given bus stop
-router.get("/:stopNo/buses", async (req, res) => {
-  await getBusesOnStop(req, res);
 });
 
 // GET bus stop with given StopNo

--- a/back-end/scripts/build_routes.js
+++ b/back-end/scripts/build_routes.js
@@ -33,6 +33,8 @@ const client = new MongoClient(uri, {
   const busStopsOnRouteCollection = client
     .db("dev")
     .collection("bus-stops-on-route");
+  await busStopsOnRouteCollection.deleteMany({});
+
   await Promise.all(
     Object.entries(routeObject).map(([route, busStopsArray]) =>
       busStopsOnRouteCollection.updateOne(

--- a/back-end/scripts/stops_scraper.js
+++ b/back-end/scripts/stops_scraper.js
@@ -49,6 +49,8 @@ const client = new MongoClient(uri, {
 
   const busStopsObject = Object.fromEntries(scrapedBusStops);
   const stopsCollection = client.db("dev").collection("bus-stop");
+  await stopsCollection.deleteMany({});
+
   await Promise.all(
     Object.entries(busStopsObject).map(([_id, busStop]) =>
       stopsCollection.updateOne({ _id }, { $set: busStop }, { upsert: true })

--- a/front-end/.eslintrc
+++ b/front-end/.eslintrc
@@ -67,12 +67,7 @@
         "patterns": ["@mui/*/*/*", "!@mui/material/test-utils/*"]
       }
     ],
-    "no-unused-vars": [
-      "error",
-      {
-        "ignoreRestSiblings": false
-      }
-    ],
+    "no-unused-vars": "off",
     "prettier/prettier": [
       "warn",
       {

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "busy-bus",
+  "name": "busybus-front-end",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "busy-bus",
+      "name": "busybus-front-end",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/cache": "^11.9.3",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
+        "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@mui/icons-material": "^5.8.4",
@@ -2348,7 +2349,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
       "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
       },
@@ -19928,7 +19928,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
       "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
-      "peer": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
       }

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "busy-bus",
+  "name": "busybus-front-end",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
     "@emotion/cache": "^11.9.3",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mui/icons-material": "^5.8.4",
@@ -37,7 +38,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "npm i @fortawesome/fontawesome-svg-core && npm i @fortawesome/free-solid-svg-icons && npm i mapbox-gl && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/front-end/src/components/BusMap.js
+++ b/front-end/src/components/BusMap.js
@@ -4,7 +4,7 @@ import { faBusAlt, faMapPin, faArrowLeft, faArrowRight, faArrowUp, faArrowDown }
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Map, { Marker } from 'react-map-gl';
 import busyBusSlice from 'store/BusyBusReducer';
-import { fetchBusesOnStopAsync, fetchStopRouteEstimatesAsync, fetchBusCapacityAsync } from '../store/thunks';
+import { fetchBusesOnRouteAsync, fetchStopRouteEstimatesAsync, fetchBusCapacityAsync } from '../store/thunks';
 import CapacityDialog from './CapacityDialog';
 
 const MAP_TOKEN = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
@@ -27,11 +27,14 @@ export function BusMap() {
   const handleBusCapacityDialogToggle = () => {
     dispatch(busyBusSlice.actions.setShowBusPopUp(!dialogOpened));
   };
- 
 
   const handleBusStopClick = (busStop) => {
-    dispatch(fetchBusesOnStopAsync({ busStop }));
+    dispatch(fetchBusesOnRouteAsync({ selectedRoute }));
+    setInterval(() => dispatch(fetchBusesOnRouteAsync({ selectedRoute })), 30000);
+
     dispatch(fetchStopRouteEstimatesAsync({ busStop, selectedRoute }));
+    setInterval(() => dispatch(fetchStopRouteEstimatesAsync({ busStop, selectedRoute })), 30000);
+
     dispatch(busyBusSlice.actions.setSelectedBusStop(busStop));
     dispatch(busyBusSlice.actions.setShowSidebar(true));
   };
@@ -39,7 +42,7 @@ export function BusMap() {
   const handleBusClick = (bus) => {
     setSelectedBus(bus);
     dispatch(busyBusSlice.actions.setShowBusPopUp(true));
-    dispatch(fetchBusCapacityAsync({busNo: bus['VehicleNo']}));
+    dispatch(fetchBusCapacityAsync({ busNo: bus['VehicleNo'] }));
   };
 
   const markers = renderMarkers({
@@ -61,11 +64,7 @@ export function BusMap() {
       >
         {markers}
       </Map>
-      <CapacityDialog
-        dialogOpen={dialogOpened}
-        dialogToggle={handleBusCapacityDialogToggle}
-        bus={selectedBus}
-      />
+      <CapacityDialog dialogOpen={dialogOpened} dialogToggle={handleBusCapacityDialogToggle} bus={selectedBus} />
     </>
   );
 }

--- a/front-end/src/components/CapacityDialog.js
+++ b/front-end/src/components/CapacityDialog.js
@@ -9,7 +9,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import Typography from '@mui/material/Typography';
 import CapacityRatings from './CapacityRating';
 
-import {fetchBusCapacityAsync} from 'store/thunks';
+import { fetchBusCapacityAsync } from 'store/thunks';
 import { useDispatch } from 'react-redux';
 
 const BootstrapDialog = styled(Dialog)(({ theme }) => ({
@@ -58,14 +58,13 @@ export default function CapacityDialog({ dialogOpen, dialogToggle, bus }) {
 
   return (
     <div>
-      <BootstrapDialog fullWidth
-  maxWidth="xs" onClose={dialogToggle} aria-labelledby="customized-dialog-title" open={dialogOpen}>
+      <BootstrapDialog fullWidth maxWidth="xs" onClose={dialogToggle} aria-labelledby="customized-dialog-title" open={dialogOpen}>
         <BootstrapDialogTitle id="customized-dialog-title" onClose={dialogToggle}>
           {bus['RouteNo'] + '    ' + bus['Direction']}
         </BootstrapDialogTitle>
         <Typography sx={{ m: 0, pl: 2 }}>{'Destination: ' + bus['Destination']}</Typography>
         <DialogContent dividers>
-          <CapacityRatings busNo={bus['VehicleNo']}/>
+          <CapacityRatings busNo={bus['VehicleNo']} />
         </DialogContent>
       </BootstrapDialog>
     </div>

--- a/front-end/src/components/CapacityRating.js
+++ b/front-end/src/components/CapacityRating.js
@@ -17,8 +17,6 @@ const labels = {
   5: constants.BUS_CAPACITY_LEVEL.FULL
 };
 
-
-
 function getHoverLabelText(value) {
   return `${labels[value]}`;
 }
@@ -32,18 +30,18 @@ const StyledRating = styled(Rating)({
   }
 });
 
-export default function CapacityRatings({busNo}) {
+export default function CapacityRatings({ busNo }) {
   const [value, setValue] = React.useState(-1);
   const [hover, setHover] = React.useState(-1);
   const dispatch = useDispatch();
   let selectedBusCapacity = useSelector((state) => state.busyBus.commuter.selectedBusCapacity).roundedAvgCapacity;
-  const usefulReportCount =  useSelector((state) => state.busyBus.commuter.selectedBusCapacity).countUsefulReport;
+  const usefulReportCount = useSelector((state) => state.busyBus.commuter.selectedBusCapacity).countUsefulReport;
   const handleBusCapacityReport = () => {
-    dispatch(reportBusCapacityAysnc({busNo, capacityLevel:value}));
+    dispatch(reportBusCapacityAysnc({ busNo, capacityLevel: value }));
   };
-  
+
   function getReadOnlyLabelText(value) {
-    if (value === -1 || value === undefined) return "no report";
+    if (value === -1 || value === undefined) return 'no report';
     return `Out of ${usefulReportCount} report`;
   }
 
@@ -52,27 +50,25 @@ export default function CapacityRatings({busNo}) {
   }
 
   return (
-    <Stack
-    spacing={1}
-    >
+    <Stack spacing={1}>
       <Typography gutterBottom>Current Capacity:</Typography>
       <Box
-      sx={{
-        width: 200,
-        display: 'flex',
-        alignItems: 'center',
-      }}
-    >
-      <StyledRating
-        value={selectedBusCapacity < 0? 0 : selectedBusCapacity}
-        precision={0.5}
-        readOnly
-        icon={<FontAwesomeIcon icon={faPerson} />}
-        emptyIcon={<FontAwesomeIcon icon={faPerson} />}
-      />
-      <Box sx={{ ml: 2 }}>{getReadOnlyLabelText(selectedBusCapacity)}</Box>
-    </Box>
-      
+        sx={{
+          width: 200,
+          display: 'flex',
+          alignItems: 'center'
+        }}
+      >
+        <StyledRating
+          value={selectedBusCapacity < 0 ? 0 : selectedBusCapacity}
+          precision={0.5}
+          readOnly
+          icon={<FontAwesomeIcon icon={faPerson} />}
+          emptyIcon={<FontAwesomeIcon icon={faPerson} />}
+        />
+        <Box sx={{ ml: 2 }}>{getReadOnlyLabelText(selectedBusCapacity)}</Box>
+      </Box>
+
       <Typography gutterBottom>Report Capacity:</Typography>
       <Box
         sx={{
@@ -98,7 +94,7 @@ export default function CapacityRatings({busNo}) {
         {value !== null && <Box sx={{ ml: 2 }}>{labels[hover !== -1 ? hover : value]}</Box>}
       </Box>
       <Button autoFocus onClick={handleBusCapacityReport}>
-          Save changes
+        Save changes
       </Button>
     </Stack>
   );

--- a/front-end/src/layout/MainLayout/Header/SearchSection/index.js
+++ b/front-end/src/layout/MainLayout/Header/SearchSection/index.js
@@ -1,126 +1,11 @@
-import PropTypes from 'prop-types';
-import { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import TextField from '@mui/material/TextField';
+import { Box } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
-
-// material-ui
-import { useTheme, styled } from '@mui/material/styles';
-import { Avatar, Box, ButtonBase, Card, Grid, InputAdornment, OutlinedInput, Popper } from '@mui/material';
-
-// third-party
-import PopupState, { bindPopper, bindToggle } from 'material-ui-popup-state';
-
-// project imports
-import Transitions from 'ui-component/extended/Transitions';
-
-// assets
-import { IconAdjustmentsHorizontal, IconSearch, IconX } from '@tabler/icons';
-import { shouldForwardProp } from '@mui/system';
-
-// actions
-import busyBusSlice from 'store/BusyBusReducer';
-
-// styles
-const PopperStyle = styled(Popper, { shouldForwardProp })(({ theme }) => ({
-  zIndex: 1100,
-  width: '99%',
-  top: '-55px !important',
-  padding: '0 12px',
-  [theme.breakpoints.down('sm')]: {
-    padding: '0 10px'
-  }
-}));
-
-const OutlineInputStyle = styled(OutlinedInput, { shouldForwardProp })(({ theme }) => ({
-  width: 434,
-  marginLeft: 16,
-  paddingLeft: 16,
-  paddingRight: 16,
-  '& input': {
-    background: 'transparent !important',
-    paddingLeft: '4px !important'
-  },
-  [theme.breakpoints.down('lg')]: {
-    width: 250
-  },
-  [theme.breakpoints.down('md')]: {
-    width: '100%',
-    marginLeft: 4,
-    background: '#fff'
-  }
-}));
-
-const HeaderAvatarStyle = styled(Avatar, { shouldForwardProp })(({ theme }) => ({
-  ...theme.typography.commonAvatar,
-  ...theme.typography.mediumAvatar,
-  background: theme.palette.secondary.light,
-  color: theme.palette.secondary.dark,
-  '&:hover': {
-    background: theme.palette.secondary.dark,
-    color: theme.palette.secondary.light
-  }
-}));
-
-// ==============================|| SEARCH INPUT - MOBILE||============================== //
-
-const MobileSearch = ({ value, setValue, popupState }) => {
-  const theme = useTheme();
-
-  return (
-    <OutlineInputStyle
-      id="input-search-header"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      placeholder="Search"
-      startAdornment={
-        <InputAdornment position="start">
-          <IconSearch stroke={1.5} size="1rem" color={theme.palette.grey[500]} />
-        </InputAdornment>
-      }
-      endAdornment={
-        <InputAdornment position="end">
-          <ButtonBase sx={{ borderRadius: '12px' }}>
-            <HeaderAvatarStyle variant="rounded">
-              <IconAdjustmentsHorizontal stroke={1.5} size="1.3rem" />
-            </HeaderAvatarStyle>
-          </ButtonBase>
-          <Box sx={{ ml: 2 }}>
-            <ButtonBase sx={{ borderRadius: '12px' }}>
-              <Avatar
-                variant="rounded"
-                sx={{
-                  ...theme.typography.commonAvatar,
-                  ...theme.typography.mediumAvatar,
-                  background: theme.palette.orange.light,
-                  color: theme.palette.orange.dark,
-                  '&:hover': {
-                    background: theme.palette.orange.dark,
-                    color: theme.palette.orange.light
-                  }
-                }}
-                {...bindToggle(popupState)}
-              >
-                <IconX stroke={1.5} size="1.3rem" />
-              </Avatar>
-            </ButtonBase>
-          </Box>
-        </InputAdornment>
-      }
-      aria-describedby="search-helper-text"
-      inputProps={{ 'aria-label': 'weight' }}
-    />
-  );
-};
-
-MobileSearch.propTypes = {
-  value: PropTypes.string,
-  setValue: PropTypes.func,
-  popupState: PopupState
-};
-
+import TextField from '@mui/material/TextField';
 import * as React from 'react';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import busyBusSlice from 'store/BusyBusReducer';
 import { fetchRoutesAsync, fetchStopsOnRouteAsync } from '../../../../store/thunks';
 
 const SearchAutoComplete = () => {
@@ -149,7 +34,7 @@ const SearchAutoComplete = () => {
       loading={loading}
       onChange={(event, v) => {
         if (v === null) {
-          dispatch(busyBusSlice.actions.setShowSidebar(false)); // hide sidebar
+          dispatch(busyBusSlice.actions.setShowSidebar(false));
           dispatch(busyBusSlice.actions.clearStopsAndBuses());
           return; // control was cleared
         }
@@ -176,57 +61,11 @@ const SearchAutoComplete = () => {
   );
 };
 
-// ==============================|| SEARCH INPUT ||============================== //
-
 const SearchSection = () => {
-  const theme = useTheme();
-
   return (
-    <>
-      <Box sx={{ display: { xs: 'block', md: 'none' } }}>
-        <PopupState variant="popper" popupId="demo-popup-popper">
-          {(popupState) => (
-            <>
-              <Box sx={{ ml: 2 }}>
-                <ButtonBase sx={{ borderRadius: '12px' }}>
-                  <HeaderAvatarStyle variant="rounded" {...bindToggle(popupState)}>
-                    <IconSearch stroke={1.5} size="1.2rem" />
-                  </HeaderAvatarStyle>
-                </ButtonBase>
-              </Box>
-              <PopperStyle {...bindPopper(popupState)} transition>
-                {({ TransitionProps }) => (
-                  <>
-                    <Transitions type="zoom" {...TransitionProps} sx={{ transformOrigin: 'center left' }}>
-                      <Card
-                        sx={{
-                          background: '#fff',
-                          [theme.breakpoints.down('sm')]: {
-                            border: 0,
-                            boxShadow: 'none'
-                          }
-                        }}
-                      >
-                        <Box sx={{ p: 2 }}>
-                          <Grid container alignItems="center" justifyContent="space-between">
-                            <Grid item xs>
-                              <MobileSearch value={value} setValue={setValue} popupState={popupState} />
-                            </Grid>
-                          </Grid>
-                        </Box>
-                      </Card>
-                    </Transitions>
-                  </>
-                )}
-              </PopperStyle>
-            </>
-          )}
-        </PopupState>
-      </Box>
-      <Box sx={{ display: { xs: 'none', md: 'block' } }}>
-        <SearchAutoComplete />
-      </Box>
-    </>
+    <Box>
+      <SearchAutoComplete />
+    </Box>
   );
 };
 

--- a/front-end/src/layout/MainLayout/Header/index.js
+++ b/front-end/src/layout/MainLayout/Header/index.js
@@ -13,10 +13,7 @@ const Header = ({ handleLeftDrawerToggle }) => {
       <Box
         sx={{
           width: 55,
-          display: 'flex',
-          [theme.breakpoints.down('md')]: {
-            width: 'auto'
-          }
+          display: 'flex'
         }}
       >
         <ButtonBase sx={{ borderRadius: '12px', overflow: 'hidden' }}>

--- a/front-end/src/store/BusyBusReducer.js
+++ b/front-end/src/store/BusyBusReducer.js
@@ -1,7 +1,13 @@
 import { createSlice } from '@reduxjs/toolkit';
 // import { v4 as uuid } from 'uuid';
 // import { BUS_CAPACITY_LEVEL } from './constants';
-import { fetchBusesOnStopAsync, fetchRoutesAsync, fetchStopRouteEstimatesAsync, fetchStopsOnRouteAsync, fetchBusCapacityAsync } from './thunks';
+import {
+  fetchBusesOnRouteAsync,
+  fetchRoutesAsync,
+  fetchStopRouteEstimatesAsync,
+  fetchStopsOnRouteAsync,
+  fetchBusCapacityAsync
+} from './thunks';
 
 export const initialState = {
   defaultId: 'default',
@@ -34,7 +40,7 @@ const busyBusSlice = createSlice({
     setShowSidebar: (state, action) => {
       state.opened = action.payload;
     },
-    setShowBusPopUp:  (state, action) => {
+    setShowBusPopUp: (state, action) => {
       state.busPopupOpened = action.payload;
     },
     clearStopsAndBuses: (state) => {
@@ -55,7 +61,7 @@ const busyBusSlice = createSlice({
     builder.addCase(fetchStopsOnRouteAsync.fulfilled, (state, action) => {
       state.commuter.busStopsSearchResult = action.payload;
     });
-    builder.addCase(fetchBusesOnStopAsync.fulfilled, (state, action) => {
+    builder.addCase(fetchBusesOnRouteAsync.fulfilled, (state, action) => {
       state.commuter.busesToShow = action.payload;
       state.commuter.stopRoutesList = getRoutesFromBuses(action.payload);
     });

--- a/front-end/src/store/actionTypes.js
+++ b/front-end/src/store/actionTypes.js
@@ -5,7 +5,7 @@ export const MENU_OPEN = '@busyBus/MENU_OPEN'; // LogoSection, not in use
 
 export const FETCH_ROUTES = '@busyBus/FETCH_ROUTES';
 export const FETCH_STOP_ON_ROUTE = '@busyBus/FETCH_STOP_ON_ROUTE';
-export const FETCH_BUSES_ON_STOP = '@busyBus/FETCH_BUSES_ON_STOP';
+export const FETCH_BUSES_ON_ROUTE = '@busyBus/FETCH_BUSES_ON_ROUTE';
 export const FETCH_ESTIMATE = '@busyBus/FETCH_ESTIMATE';
 export const SEARCH_BUS_STOP = '@busyBus/SEARCH_BUS_STOP';
 export const GET_BUS_STOPS_BY_ROUTE = '@busyBus/GET_BUS_STOPS_BY_ROUTE';

--- a/front-end/src/store/service.js
+++ b/front-end/src/store/service.js
@@ -1,5 +1,7 @@
+const API_URL = 'https://busybus-back-end.onrender.com';
+
 const fetchRoutes = async () => {
-  const response = await fetch('http://localhost:3001/routes', {
+  const response = await fetch(`${API_URL}/routes`, {
     method: 'GET'
   });
 
@@ -7,16 +9,15 @@ const fetchRoutes = async () => {
 };
 
 const fetchStopsOnRoute = async ({ routeNo }) => {
-  const response = await fetch(`http://localhost:3001/routes/${routeNo}`, {
+  const response = await fetch(`${API_URL}/routes/${routeNo}`, {
     method: 'GET'
   });
 
   return response.json();
 };
 
-const fetchBusesOnStop = async ({ busStop }) => {
-  const stopNo = busStop['StopNo'];
-  const response = await fetch(`http://localhost:3001/stops/${stopNo}/buses`, {
+const fetchBusesOnRoute = async ({ selectedRoute }) => {
+  const response = await fetch(`${API_URL}/routes/${selectedRoute}/buses`, {
     method: 'GET'
   });
 
@@ -25,7 +26,7 @@ const fetchBusesOnStop = async ({ busStop }) => {
 
 const fetchStopRouteEstimates = async ({ busStop, selectedRoute }) => {
   const stopNo = busStop['StopNo'];
-  const response = await fetch(`http://localhost:3001/estimates/${stopNo}/${selectedRoute}`, {
+  const response = await fetch(`${API_URL}/estimates/${stopNo}/${selectedRoute}`, {
     method: 'GET'
   });
 
@@ -33,7 +34,7 @@ const fetchStopRouteEstimates = async ({ busStop, selectedRoute }) => {
 };
 
 const fetchBusCapacity = async ({ busNo }) => {
-  const response = await fetch(`http://localhost:3001/capacity/${busNo}`, {
+  const response = await fetch(`${API_URL}/capacity/${busNo}`, {
     method: 'GET'
   });
 
@@ -41,12 +42,12 @@ const fetchBusCapacity = async ({ busNo }) => {
 };
 
 const reportBusCapacity = async ({ busNo, capacityLevel }) => {
-  const response = await fetch(`http://localhost:3001/capacity/${busNo}`, {
+  const response = await fetch(`${API_URL}/capacity/${busNo}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({capacityLevel: capacityLevel})
+    body: JSON.stringify({ capacityLevel: capacityLevel })
   });
 
   return response.json();
@@ -55,7 +56,7 @@ const reportBusCapacity = async ({ busNo, capacityLevel }) => {
 const BusyBusService = {
   fetchRoutes,
   fetchStopsOnRoute,
-  fetchBusesOnStop,
+  fetchBusesOnRoute,
   fetchStopRouteEstimates,
   fetchBusCapacity,
   reportBusCapacity

--- a/front-end/src/store/thunks.js
+++ b/front-end/src/store/thunks.js
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import {
   FETCH_ROUTES,
-  FETCH_BUSES_ON_STOP,
+  FETCH_BUSES_ON_ROUTE,
   FETCH_STOP_ON_ROUTE,
   FETCH_ESTIMATE,
   FETCH_BUS_CAPACITY,
@@ -17,8 +17,8 @@ export const fetchStopsOnRouteAsync = createAsyncThunk(FETCH_STOP_ON_ROUTE, asyn
   return await BusyBusService.fetchStopsOnRoute({ routeNo });
 });
 
-export const fetchBusesOnStopAsync = createAsyncThunk(FETCH_BUSES_ON_STOP, async ({ busStop }) => {
-  return await BusyBusService.fetchBusesOnStop({ busStop });
+export const fetchBusesOnRouteAsync = createAsyncThunk(FETCH_BUSES_ON_ROUTE, async ({ selectedRoute }) => {
+  return await BusyBusService.fetchBusesOnRoute({ selectedRoute });
 });
 
 export const fetchStopRouteEstimatesAsync = createAsyncThunk(FETCH_ESTIMATE, async ({ busStop, selectedRoute }) => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "busybus",
+  "version": "1.0.0",
+  "description": "Group members: Dmitriy B., Dennis F., Lisa L. and Brendon S.",
+  "main": "index.js",
+  "scripts": {
+    "build:client": "cd front-end && npm install && npm run build",
+    "start:client": "cd front-end && npm run start",
+    "build:backend": "cd back-end && npm install",
+    "start:backend": "cd back-end && npm run start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Simplified the UI by removing the mobile-only search and rather using the regular search in small-screen mode

A few clean-ups in the scraper and route builder (delete collection before saving)

Added package.json to root for use in deployment later

UPDATE: Moved deleting outdated capacities into an interval and fetching buses at an interval

Also ran prettier on the whole repo