### PR TITLE
fix bug where intervals were not replaced

### DIFF
--- a/front-end/src/components/BusMap.js
+++ b/front-end/src/components/BusMap.js
@@ -28,13 +28,18 @@ export function BusMap() {
   const handleBusCapacityDialogToggle = () => {
     dispatch(busyBusSlice.actions.setShowBusPopUp(!dialogOpened));
   };
+  const [busesInterval, setBusesInterval] = useState(-1);
+  const [estimatesInterval, setEstimatesInterval] = useState(-1);
 
   const handleBusStopClick = (busStop) => {
+    clearInterval(busesInterval);
+    clearInterval(estimatesInterval);
+
     dispatch(fetchBusesOnRouteAsync({ selectedRoute }));
-    setInterval(() => dispatch(fetchBusesOnRouteAsync({ selectedRoute })), 30000);
+    setBusesInterval(setInterval(() => dispatch(fetchBusesOnRouteAsync({ selectedRoute })), 30000));
 
     dispatch(fetchStopRouteEstimatesAsync({ busStop, selectedRoute }));
-    setInterval(() => dispatch(fetchStopRouteEstimatesAsync({ busStop, selectedRoute })), 30000);
+    setEstimatesInterval(setInterval(() => dispatch(fetchStopRouteEstimatesAsync({ busStop, selectedRoute })), 30000));
 
     dispatch(busyBusSlice.actions.setSelectedBusStop(busStop));
     dispatch(busyBusSlice.actions.setShowSidebar(true));


### PR DESCRIPTION
the intervals currently stack, which causes the UI to fetch as many times as there are searches. this removes that behaviour and clears each interval before setting it.